### PR TITLE
feat: implement entitlement middleware

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,7 +77,10 @@ func main() {
 	entitlementService := services.NewEntitlementService(db)
 	planHandler := handlers.NewPlanHandler(entitlementService)
 	aiService := services.NewMockAIService()
-	aiHandler := handlers.NewAIHandler(entitlementService, aiService)
+	aiHandler := handlers.NewAIHandler(aiService)
+
+	// Middleware の初期化
+	entitlementMiddleware := middleware.NewEntitlementMiddleware(entitlementService)
 
 	// Ginエンジンのインスタンスを作成
 	r := gin.Default()
@@ -85,6 +88,7 @@ func main() {
 	docs.SwaggerInfo.BasePath = "/api/v1"
 	v1 := r.Group("/api/v1")
 	v1.Use(authMiddleware)
+	v1.Use(entitlementMiddleware)
 	{
 		v1.GET("/users", handlers.GetUsers(db))
 		v1.GET("/me/plan", planHandler.GetMePlan)

--- a/internal/middleware/entitlement.go
+++ b/internal/middleware/entitlement.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"what-went-wrong-api/internal/models"
+	"what-went-wrong-api/internal/services"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type EntitlementManager interface {
+	GetPlan(userID uuid.UUID) (*models.UserPlan, error)
+	GetEntitlements(planName string) services.Entitlements
+}
+
+func NewEntitlementMiddleware(service EntitlementManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userIDStr, exists := c.Get("userID")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			c.Abort()
+			return
+		}
+
+		userID, err := uuid.Parse(userIDStr.(string))
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid user ID"})
+			c.Abort()
+			return
+		}
+
+		plan, err := service.GetPlan(userID)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get user plan"})
+			c.Abort()
+			return
+		}
+
+		entitlements := service.GetEntitlements(plan.Plan)
+
+		c.Set("entitlements", entitlements)
+		c.Next()
+	}
+}


### PR DESCRIPTION
Closes #8. Implements EntitlementMiddleware to hydrate request context with user entitlements and refactors AIHandler to use it.