### PR TITLE
feat: add seed data for all models

### DIFF
--- a/internal/models/excuse_entry.go
+++ b/internal/models/excuse_entry.go
@@ -8,9 +8,9 @@ import (
 
 type ExcuseEntry struct {
 	ID         uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
-	UserID     uuid.UUID `gorm:"type:uuid;not null;index"`
-	GoalID     uuid.UUID `gorm:"type:uuid;not null;index"`
-	Date       string    `gorm:"type:date;not null;index:idx_user_goal_date,unique"` // YYYY-MM-DD
+	UserID     uuid.UUID `gorm:"type:uuid;not null;index;uniqueIndex:idx_user_goal_date"`
+	GoalID     uuid.UUID `gorm:"type:uuid;not null;index;uniqueIndex:idx_user_goal_date"`
+	Date       string    `gorm:"type:date;not null;uniqueIndex:idx_user_goal_date"` // YYYY-MM-DD
 	ExcuseText string    `gorm:"type:text;not null"`
 	TemplateID *string   `gorm:"size:255"`
 	CreatedAt  time.Time `gorm:"default:CURRENT_TIMESTAMP"`

--- a/internal/seed/excuse_entry.go
+++ b/internal/seed/excuse_entry.go
@@ -18,7 +18,7 @@ func SeedExcuseEntries(db *gorm.DB) error {
 	}
 
 	var goals []models.Goal
-	if err := db.Preload("User").Find(&goals).Error; err != nil {
+	if err := db.Find(&goals).Error; err != nil {
 		return err
 	}
 

--- a/internal/seed/excuse_entry.go
+++ b/internal/seed/excuse_entry.go
@@ -1,0 +1,60 @@
+package seed
+
+import (
+	"time"
+	"what-went-wrong-api/internal/models"
+
+	"gorm.io/gorm"
+)
+
+func SeedExcuseEntries(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.ExcuseEntry{}).Count(&count).Error; err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	var goals []models.Goal
+	if err := db.Preload("User").Find(&goals).Error; err != nil {
+		return err
+	}
+
+	// Assuming templates are already seeded
+	templateID := "gravity-strong"
+
+	var entries []models.ExcuseEntry
+
+	today := time.Now().Format("2006-01-02")
+	yesterday := time.Now().AddDate(0, 0, -1).Format("2006-01-02")
+
+	for i, goal := range goals {
+		// Create entry for today for some goals
+		if i%2 == 0 {
+			entries = append(entries, models.ExcuseEntry{
+				UserID:     goal.UserID,
+				GoalID:     goal.ID,
+				Date:       today,
+				ExcuseText: "It was too hard.",
+				TemplateID: nil,
+			})
+		} else {
+			// Create entry for yesterday
+			entries = append(entries, models.ExcuseEntry{
+				UserID:     goal.UserID,
+				GoalID:     goal.ID,
+				Date:       yesterday,
+				ExcuseText: "Gravity was unusually strong.",
+				TemplateID: &templateID,
+			})
+		}
+	}
+
+	if len(entries) > 0 {
+		return db.Create(&entries).Error
+	}
+
+	return nil
+}

--- a/internal/seed/excuse_entry.go
+++ b/internal/seed/excuse_entry.go
@@ -37,7 +37,7 @@ func SeedExcuseEntries(db *gorm.DB) error {
 				UserID:     goal.UserID,
 				GoalID:     goal.ID,
 				Date:       today,
-				ExcuseText: "It was too hard.",
+				ExcuseText: "難しすぎた。",
 				TemplateID: nil,
 			})
 		} else {
@@ -46,7 +46,7 @@ func SeedExcuseEntries(db *gorm.DB) error {
 				UserID:     goal.UserID,
 				GoalID:     goal.ID,
 				Date:       yesterday,
-				ExcuseText: "Gravity was unusually strong.",
+				ExcuseText: "重力が異常に強かった。",
 				TemplateID: &templateID,
 			})
 		}

--- a/internal/seed/excuse_template.go
+++ b/internal/seed/excuse_template.go
@@ -1,0 +1,56 @@
+package seed
+
+import (
+	"what-went-wrong-api/internal/models"
+
+	"github.com/lib/pq"
+	"gorm.io/gorm"
+)
+
+func SeedExcuseTemplates(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.ExcuseTemplate{}).Count(&count).Error; err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	templates := []models.ExcuseTemplate{
+		{
+			ID:        "gravity-strong",
+			Text:      "Today, gravity was unusually strong.",
+			PackID:    "core",
+			IsActive:  true,
+			IsPremium: false,
+			Tags:      pq.StringArray{"physics", "funny"},
+		},
+		{
+			ID:        "cat-monitor",
+			Text:      "My cat fell asleep on my monitor.",
+			PackID:    "core",
+			IsActive:  true,
+			IsPremium: false,
+			Tags:      pq.StringArray{"cat", "cute"},
+		},
+		{
+			ID:        "coffee-spill",
+			Text:      "I spilled coffee on my keyboard.",
+			PackID:    "core",
+			IsActive:  true,
+			IsPremium: false,
+			Tags:      pq.StringArray{"accident", "coffee"},
+		},
+		{
+			ID:        "aliens",
+			Text:      "Aliens abducted my motivation.",
+			PackID:    "surreal",
+			IsActive:  true,
+			IsPremium: true,
+			Tags:      pq.StringArray{"scifi", "alien"},
+		},
+	}
+
+	return db.Create(&templates).Error
+}

--- a/internal/seed/excuse_template.go
+++ b/internal/seed/excuse_template.go
@@ -20,35 +20,35 @@ func SeedExcuseTemplates(db *gorm.DB) error {
 	templates := []models.ExcuseTemplate{
 		{
 			ID:        "gravity-strong",
-			Text:      "Today, gravity was unusually strong.",
+			Text:      "今日は重力が強かった。",
 			PackID:    "core",
 			IsActive:  true,
 			IsPremium: false,
-			Tags:      pq.StringArray{"physics", "funny"},
+			Tags:      pq.StringArray{"物理", "面白い"},
 		},
 		{
 			ID:        "cat-monitor",
-			Text:      "My cat fell asleep on my monitor.",
+			Text:      "猫がモニターの上で寝てしまった。",
 			PackID:    "core",
 			IsActive:  true,
 			IsPremium: false,
-			Tags:      pq.StringArray{"cat", "cute"},
+			Tags:      pq.StringArray{"猫", "かわいい"},
 		},
 		{
 			ID:        "coffee-spill",
-			Text:      "I spilled coffee on my keyboard.",
+			Text:      "キーボードにコーヒーをこぼした。",
 			PackID:    "core",
 			IsActive:  true,
 			IsPremium: false,
-			Tags:      pq.StringArray{"accident", "coffee"},
+			Tags:      pq.StringArray{"事故", "コーヒー"},
 		},
 		{
 			ID:        "aliens",
-			Text:      "Aliens abducted my motivation.",
+			Text:      "エイリアンにやる気を奪われた。",
 			PackID:    "surreal",
 			IsActive:  true,
 			IsPremium: true,
-			Tags:      pq.StringArray{"scifi", "alien"},
+			Tags:      pq.StringArray{"SF", "エイリアン"},
 		},
 	}
 

--- a/internal/seed/goal.go
+++ b/internal/seed/goal.go
@@ -1,0 +1,49 @@
+package seed
+
+import (
+	"what-went-wrong-api/internal/models"
+
+	"gorm.io/gorm"
+)
+
+func SeedGoals(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.Goal{}).Count(&count).Error; err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	var users []models.User
+	if err := db.Find(&users).Error; err != nil {
+		return err
+	}
+
+	var goals []models.Goal
+
+	for _, user := range users {
+		notifTime := "09:00"
+		goals = append(goals, models.Goal{
+			UserID:              user.ID,
+			Title:               "Wake up early",
+			NotificationTime:    &notifTime,
+			NotificationEnabled: true,
+			Order:               1,
+		})
+
+		goals = append(goals, models.Goal{
+			UserID:              user.ID,
+			Title:               "Study Go",
+			NotificationEnabled: false,
+			Order:               2,
+		})
+	}
+
+	if len(goals) > 0 {
+		return db.Create(&goals).Error
+	}
+
+	return nil
+}

--- a/internal/seed/goal.go
+++ b/internal/seed/goal.go
@@ -27,7 +27,7 @@ func SeedGoals(db *gorm.DB) error {
 		notifTime := "09:00"
 		goals = append(goals, models.Goal{
 			UserID:              user.ID,
-			Title:               "Wake up early",
+			Title:               "早起きする",
 			NotificationTime:    &notifTime,
 			NotificationEnabled: true,
 			Order:               1,
@@ -35,7 +35,7 @@ func SeedGoals(db *gorm.DB) error {
 
 		goals = append(goals, models.Goal{
 			UserID:              user.ID,
-			Title:               "Study Go",
+			Title:               "Go言語を勉強する",
 			NotificationEnabled: false,
 			Order:               2,
 		})

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -13,6 +13,22 @@ func Run(db *gorm.DB) error {
 			return fmt.Errorf("failed to seed users: %w", err)
 		}
 
+		if err := SeedUserPlans(tx); err != nil {
+			return fmt.Errorf("failed to seed user plans: %w", err)
+		}
+
+		if err := SeedGoals(tx); err != nil {
+			return fmt.Errorf("failed to seed goals: %w", err)
+		}
+
+		if err := SeedExcuseTemplates(tx); err != nil {
+			return fmt.Errorf("failed to seed excuse templates: %w", err)
+		}
+
+		if err := SeedExcuseEntries(tx); err != nil {
+			return fmt.Errorf("failed to seed excuse entries: %w", err)
+		}
+
 		log.Println("Database seeding completed successfully")
 		return nil
 	})

--- a/internal/seed/user_plan.go
+++ b/internal/seed/user_plan.go
@@ -1,0 +1,42 @@
+package seed
+
+import (
+	"what-went-wrong-api/internal/models"
+
+	"gorm.io/gorm"
+)
+
+func SeedUserPlans(db *gorm.DB) error {
+	var count int64
+	if err := db.Model(&models.UserPlan{}).Count(&count).Error; err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return nil
+	}
+
+	var users []models.User
+	if err := db.Find(&users).Error; err != nil {
+		return err
+	}
+
+	var plans []models.UserPlan
+	for _, user := range users {
+		planType := "free"
+		if user.Email == "jiro@example.com" {
+			planType = "premium"
+		}
+
+		plans = append(plans, models.UserPlan{
+			UserID: user.ID,
+			Plan:   planType,
+		})
+	}
+
+	if len(plans) > 0 {
+		return db.Create(&plans).Error
+	}
+
+	return nil
+}


### PR DESCRIPTION
- internal/models に存在する各モデル (Goal, UserPlan, ExcuseTemplate, ExcuseEntry) のシードデータを追加しました。
- internal/seed/seed.go を更新し、全モデルのシード関数を呼び出すようにしました。
- 開発環境でのみ実行されます。