### PR TITLE
Add GET /api/v1/goals/{id} endpoint

### DIFF
--- a/cmd/docs/docs.go
+++ b/cmd/docs/docs.go
@@ -589,6 +589,59 @@ const docTemplate = `{
             }
         },
         "/goals/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a single goal by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "goals"
+                ],
+                "summary": "Get goal details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Goal ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateGoalResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GoalUnauthorizedResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GoalNotFoundErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GoalFetchErrorResponse"
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {

--- a/cmd/docs/swagger.json
+++ b/cmd/docs/swagger.json
@@ -582,6 +582,59 @@
             }
         },
         "/goals/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a single goal by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "goals"
+                ],
+                "summary": "Get goal details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Goal ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CreateGoalResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GoalUnauthorizedResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GoalNotFoundErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.GoalFetchErrorResponse"
+                        }
+                    }
+                }
+            },
             "delete": {
                 "security": [
                     {

--- a/cmd/docs/swagger.yaml
+++ b/cmd/docs/swagger.yaml
@@ -782,6 +782,40 @@ paths:
       summary: Delete goal
       tags:
       - goals
+    get:
+      consumes:
+      - application/json
+      description: Get a single goal by ID
+      parameters:
+      - description: Goal ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.CreateGoalResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/handlers.GoalUnauthorizedResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/handlers.GoalNotFoundErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/handlers.GoalFetchErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get goal details
+      tags:
+      - goals
     patch:
       consumes:
       - application/json

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -97,14 +97,15 @@ func main() {
 		v1.POST("/ai-excuse", aiHandler.PostAiExcuse)
 		v1.GET("/goals", goalHandler.GetGoals)
 		v1.POST("/goals", goalHandler.PostGoals)
+		v1.GET("/goals/:id", goalHandler.GetGoal)
 		v1.PATCH("/goals/:id", goalHandler.PatchGoal)
 		v1.DELETE("/goals/:id", goalHandler.DeleteGoal)
 		v1.GET("/excuse-templates", excuseTemplateHandler.GetExcuseTemplates)
 		v1.GET("/excuse-templates/:id", excuseTemplateHandler.GetExcuseTemplate)
 
-		v1.GET("/goals/:goal_id/excuses", excuseHandler.GetExcuses)
-		v1.GET("/goals/:goal_id/excuses/today", excuseHandler.GetExcuseToday)
-		v1.POST("/goals/:goal_id/excuses", excuseHandler.PostExcuse)
+		v1.GET("/goals/:id/excuses", excuseHandler.GetExcuses)
+		v1.GET("/goals/:id/excuses/today", excuseHandler.GetExcuseToday)
+		v1.POST("/goals/:id/excuses", excuseHandler.PostExcuse)
 		v1.PATCH("/excuses/:id", excuseHandler.PatchExcuse)
 		v1.DELETE("/excuses/:id", excuseHandler.DeleteExcuse)
 	}

--- a/docs/SERVER_SPEC.md
+++ b/docs/SERVER_SPEC.md
@@ -122,15 +122,26 @@ Goal作成。
 }
 ```
 
-### 3.3 PATCH /goals/{goalId}
+### 3.3 GET /goals/{goalId}
+指定したGoalの詳細を取得。
+
+#### レスポンス 200
+
+```json
+{
+  "goal": { ...Goal }
+}
+```
+
+### 3.4 PATCH /goals/{goalId}
 Goal更新（タイトル、通知等）。
 エンタイトルメントに特別な制限なし。
 
-### 3.4 DELETE /goals/{goalId}
+### 3.5 DELETE /goals/{goalId}
 Goal削除＋紐づくExcuseEntry削除。
 エンタイトルメントに特別な制限なし。
 
-### 3.5 GET /excuse-templates
+### 3.6 GET /excuse-templates
 
 #### クエリパラメータ（任意）
 - `packId`： `core` / `pack.surreal` / `pack.sf` 等
@@ -156,7 +167,7 @@ Goal削除＋紐づくExcuseEntry削除。
 }
 ```
 
-### 3.6 GET /goals/{goalId}/excuses
+### 3.7 GET /goals/{goalId}/excuses
 
 #### 役割
 
@@ -190,14 +201,14 @@ Goalごとの過去ログ取得。
 }
 ```
 
-### 3.7 GET /goals/{goalId}/excuses/today
+### 3.8 GET /goals/{goalId}/excuses/today
 
 - (goalId, today) の ExcuseEntryを1件返す
 - なければ 404 ExcuseEntryNotFoundForToday
 
 （課金制御は特になし）
 
-### 3.8 POST /goals/{goalId}/excuses
+### 3.9 POST /goals/{goalId}/excuses
 
 #### 今日を含む任意の日付の言い訳保存（upsert）。
 
@@ -228,17 +239,17 @@ Goalごとの過去ログ取得。
 }
 ```
 
-### 3.9 PATCH /excuses/{excuseId}
+### 3.10 PATCH /excuses/{excuseId}
 
 - `excuseText` / `templateId` を更新
 - `templateId` 変更時は利用可能テンプレかチェック
 
-### 3.10 DELETE /excuses/{excuseId}
+### 3.11 DELETE /excuses/{excuseId}
 
 - ExcuseEntry削除 → その日が「できた扱い」に戻る
 - 課金制御なし
 
-### 3.11 GET /me/plan
+### 3.12 GET /me/plan
 現在のプランと権限を返す。
 
 ```json
@@ -253,7 +264,7 @@ Goalごとの過去ログ取得。
 }
 ```
 
-### 3.12 POST /me/plan
+### 3.13 POST /me/plan
 
 #### 概要
 
@@ -281,7 +292,7 @@ Goalごとの過去ログ取得。
 }
 ```
 
-### 3.13 POST /ai-excuse
+### 3.14 POST /ai-excuse
 
 #### 概要
 

--- a/internal/handlers/excuse.go
+++ b/internal/handlers/excuse.go
@@ -43,7 +43,6 @@ func (h *ExcuseHandler) GetExcuses(c *gin.Context) {
 	}
 	userID := userIdStr.(string)
 
-	// Gin conflict: :id param is used for /goals/:id
 	goalIDStr := c.Param("id")
 	goalID, err := uuid.Parse(goalIDStr)
 	if err != nil {
@@ -120,7 +119,6 @@ func (h *ExcuseHandler) GetExcuseToday(c *gin.Context) {
 	}
 	userID := userIdStr.(string)
 
-	// Gin conflict: :id param is used for /goals/:id
 	goalIDStr := c.Param("id")
 	goalID, err := uuid.Parse(goalIDStr)
 	if err != nil {
@@ -168,7 +166,6 @@ func (h *ExcuseHandler) GetExcuseToday(c *gin.Context) {
 func (h *ExcuseHandler) PostExcuse(c *gin.Context) {
 	userIdStr, _ := c.Get("userID")
 	userID := userIdStr.(string)
-	// Gin conflict: :id param is used for /goals/:id
 	goalIDStr := c.Param("id")
 	goalID, err := uuid.Parse(goalIDStr)
 	if err != nil {

--- a/internal/handlers/excuse.go
+++ b/internal/handlers/excuse.go
@@ -43,7 +43,8 @@ func (h *ExcuseHandler) GetExcuses(c *gin.Context) {
 	}
 	userID := userIdStr.(string)
 
-	goalIDStr := c.Param("goal_id")
+	// Gin conflict: :id param is used for /goals/:id
+	goalIDStr := c.Param("id")
 	goalID, err := uuid.Parse(goalIDStr)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "入力内容が正しくありません"})
@@ -119,7 +120,8 @@ func (h *ExcuseHandler) GetExcuseToday(c *gin.Context) {
 	}
 	userID := userIdStr.(string)
 
-	goalIDStr := c.Param("goal_id")
+	// Gin conflict: :id param is used for /goals/:id
+	goalIDStr := c.Param("id")
 	goalID, err := uuid.Parse(goalIDStr)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "入力内容が正しくありません"})
@@ -166,7 +168,8 @@ func (h *ExcuseHandler) GetExcuseToday(c *gin.Context) {
 func (h *ExcuseHandler) PostExcuse(c *gin.Context) {
 	userIdStr, _ := c.Get("userID")
 	userID := userIdStr.(string)
-	goalIDStr := c.Param("goal_id")
+	// Gin conflict: :id param is used for /goals/:id
+	goalIDStr := c.Param("id")
 	goalID, err := uuid.Parse(goalIDStr)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "入力内容が正しくありません"})

--- a/internal/handlers/excuse_test.go
+++ b/internal/handlers/excuse_test.go
@@ -38,7 +38,7 @@ func TestGetExcuses_Retention(t *testing.T) {
 		c, _ := gin.CreateTestContext(w)
 		c.Set("userID", userID)
 		c.Set("entitlements", services.Entitlements{LogRetentionDays: &days})
-		c.Params = gin.Params{{Key: "goal_id", Value: goalID.String()}}
+		c.Params = gin.Params{{Key: "id", Value: goalID.String()}}
 		c.Request, _ = http.NewRequest("GET", "/goals/"+goalID.String()+"/excuses", nil)
 
 		handler.GetExcuses(c)
@@ -56,7 +56,7 @@ func TestGetExcuses_Retention(t *testing.T) {
 		c, _ := gin.CreateTestContext(w)
 		c.Set("userID", userID)
 		c.Set("entitlements", services.Entitlements{LogRetentionDays: nil}) // Unlimited
-		c.Params = gin.Params{{Key: "goal_id", Value: goalID.String()}}
+		c.Params = gin.Params{{Key: "id", Value: goalID.String()}}
 		c.Request, _ = http.NewRequest("GET", "/goals/"+goalID.String()+"/excuses", nil)
 
 		handler.GetExcuses(c)
@@ -83,7 +83,7 @@ func TestPostExcuse_Upsert(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Set("userID", userID)
 	c.Set("entitlements", services.Entitlements{})
-	c.Params = gin.Params{{Key: "goal_id", Value: goalID.String()}}
+	c.Params = gin.Params{{Key: "id", Value: goalID.String()}}
 
 	reqBody := `{"date": "` + today + `", "excuseText": "First Excuse"}`
 	c.Request, _ = http.NewRequest("POST", "/goals/"+goalID.String()+"/excuses", strings.NewReader(reqBody))
@@ -101,7 +101,7 @@ func TestPostExcuse_Upsert(t *testing.T) {
 	c, _ = gin.CreateTestContext(w)
 	c.Set("userID", userID)
 	c.Set("entitlements", services.Entitlements{})
-	c.Params = gin.Params{{Key: "goal_id", Value: goalID.String()}}
+	c.Params = gin.Params{{Key: "id", Value: goalID.String()}}
 
 	reqBody = `{"date": "` + today + `", "excuseText": "Updated Excuse"}`
 	c.Request, _ = http.NewRequest("POST", "/goals/"+goalID.String()+"/excuses", strings.NewReader(reqBody))
@@ -134,7 +134,7 @@ func TestPostExcuse_PremiumTemplate(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Set("userID", userID)
 	c.Set("entitlements", services.Entitlements{CanUsePremiumTemplates: false})
-	c.Params = gin.Params{{Key: "goal_id", Value: goalID.String()}}
+	c.Params = gin.Params{{Key: "id", Value: goalID.String()}}
 
 	reqBody := `{"date": "` + today + `", "excuseText": "Using Premium", "templateId": "tmpl-premium"}`
 	c.Request, _ = http.NewRequest("POST", "/goals/"+goalID.String()+"/excuses", strings.NewReader(reqBody))

--- a/internal/handlers/goal.go
+++ b/internal/handlers/goal.go
@@ -8,6 +8,7 @@ import (
 	"what-went-wrong-api/internal/services"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -65,7 +66,7 @@ func (h *GoalHandler) GetGoals(c *gin.Context) {
 // @Tags goals
 // @Accept json
 // @Produce json
-// @Param id path string true "Goal ID"
+// @Param id path string true "Goal ID" format:uuid
 // @Success 200 {object} CreateGoalResponse
 // @Failure 401 {object} GoalUnauthorizedResponse
 // @Failure 404 {object} GoalNotFoundErrorResponse
@@ -73,7 +74,12 @@ func (h *GoalHandler) GetGoals(c *gin.Context) {
 // @Security BearerAuth
 // @Router /goals/{id} [get]
 func (h *GoalHandler) GetGoal(c *gin.Context) {
-	goalID := c.Param("id")
+	goalIDStr := c.Param("id")
+	goalID, err := uuid.Parse(goalIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "入力内容が正しくありません"})
+		return
+	}
 	userIDStr, exists := c.Get("userID")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "認証されていません"})
@@ -111,7 +117,7 @@ func (h *GoalHandler) GetGoal(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param request body CreateGoalRequest true "Request body"
-// @Success 201 {object} CreateGoalResponse
+// @Success 200 {object} CreateGoalResponse
 // @Failure 400 {object} GoalValidationErrorResponse
 // @Failure 401 {object} GoalUnauthorizedResponse
 // @Failure 403 {object} GoalLimitReachedResponse "Forbidden if max goals reached"
@@ -185,7 +191,7 @@ func (h *GoalHandler) PostGoals(c *gin.Context) {
 // @Tags goals
 // @Accept json
 // @Produce json
-// @Param id path string true "Goal ID"
+// @Param id path string true "Goal ID" format:uuid
 // @Param request body UpdateGoalRequest true "Request body"
 // @Success 200 {object} CreateGoalResponse
 // @Failure 400 {object} GoalValidationErrorResponse
@@ -195,7 +201,12 @@ func (h *GoalHandler) PostGoals(c *gin.Context) {
 // @Security BearerAuth
 // @Router /goals/{id} [patch]
 func (h *GoalHandler) PatchGoal(c *gin.Context) {
-	goalID := c.Param("id")
+	goalIDStr := c.Param("id")
+	goalID, err := uuid.Parse(goalIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "入力内容が正しくありません"})
+		return
+	}
 	userIDStr, _ := c.Get("userID")
 	userID := userIDStr.(string)
 
@@ -249,15 +260,21 @@ func (h *GoalHandler) PatchGoal(c *gin.Context) {
 // @Tags goals
 // @Accept json
 // @Produce json
-// @Param id path string true "Goal ID"
+// @Param id path string true "Goal ID" format:uuid
 // @Success 204 "No Content"
+// @Failure 400 {object} GoalValidationErrorResponse
 // @Failure 401 {object} GoalUnauthorizedResponse
 // @Failure 404 {object} GoalNotFoundErrorResponse
 // @Failure 500 {object} GoalDeleteErrorResponse
 // @Security BearerAuth
 // @Router /goals/{id} [delete]
 func (h *GoalHandler) DeleteGoal(c *gin.Context) {
-	goalID := c.Param("id")
+	goalIDStr := c.Param("id")
+	goalID, err := uuid.Parse(goalIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "入力内容が正しくありません"})
+		return
+	}
 	userIDStr, _ := c.Get("userID")
 	userID := userIDStr.(string)
 
@@ -265,7 +282,7 @@ func (h *GoalHandler) DeleteGoal(c *gin.Context) {
 	// Assuming cascade delete is configured in DB or we handle it here
 	// Spec says: Goal削除＋紐づくExcuseEntry削除
 
-	err := h.db.Transaction(func(tx *gorm.DB) error {
+	err = h.db.Transaction(func(tx *gorm.DB) error {
 		// Verify ownership
 		var goal models.Goal
 		if err := tx.First(&goal, "id = ? AND user_id = ?", goalID, userID).Error; err != nil {


### PR DESCRIPTION
Implemented GET /api/v1/goals/{id} endpoint to retrieve goal details.\n\nAlso resolved a Gin router wildcard conflict by standardizing on :id for consistency across endpoints.